### PR TITLE
#66 Add a method to retrieve a paged list of observers

### DIFF
--- a/api/MonitorizareVot.Ong/src/MonitorizareVot.Api/Controllers/Observer.cs
+++ b/api/MonitorizareVot.Ong/src/MonitorizareVot.Api/Controllers/Observer.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using MonitorizareVot.Api.ViewModels;
+using MonitorizareVot.Ong.Api.Extensions;
 
 namespace MonitorizareVot.Api.Controllers
 {
@@ -52,5 +53,17 @@ namespace MonitorizareVot.Api.Controllers
 
             return Task.FromResult(new { });
         }
+
+        /// <summary>
+        /// Retrieves a paged list of observers
+        /// </summary>
+        /// <param name="request">The request containg paging information</param>
+        /// <returns>A paged list of observers</returns>
+        [Authorize]
+        [HttpGet]
+        public async Task<ApiListResponse<ObserverModel>> Get(GetObserversRequest request)
+            => await _mediator
+                .Send(request)
+                .ConfigureAwait(false);
     }
 }

--- a/api/MonitorizareVot.Ong/src/MonitorizareVot.Api/ViewModels/GetObserversRequest.cs
+++ b/api/MonitorizareVot.Ong/src/MonitorizareVot.Api/ViewModels/GetObserversRequest.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+using MonitorizareVot.Ong.Api.Extensions;
+using MonitorizareVot.Ong.Api.ViewModels;
+
+namespace MonitorizareVot.Api.ViewModels
+{
+    public class GetObserversRequest : PagingModel, IRequest<ApiListResponse<ObserverModel>>
+    { }
+}


### PR DESCRIPTION
Not tested in any way.
Couldn't run the tests because of the error: [xUnit.net 00:00:03.2853935] Skipping: MonitorizareVot.Ong.Api.Tests (could not find dependent assembly 'System.Runtime.InteropServices, Version=4.1.1')