### PR TITLE
chore: fix sourceMap flag for build script

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve --proxyConfig proxy.conf.json",
     "start-qa": "ng serve --configuration=qa",
     "start-prod": "ng serve --configuration=prod",
-    "build": "ng build --prod --sourcemap false",
+    "build": "ng build --prod --sourceMap false",
     "build-token": "ng build --configuration=token",
     "lint": "tslint \"src/**/*.ts\"",
     "test": "ng test",


### PR DESCRIPTION
`--sourcemap` is not a valid flag anymore, see `--sourceMap` https://angular.io/cli/build
