### PR TITLE
Language Switch Menu

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,9 +14,10 @@ export class AppComponent {
     if (lang) {
       this.langIndex = this.languages.findIndex((x) => x === lang);
     } else {
-      localStorage.setItem('language', 'en');
+      localStorage.setItem('language', 'ro');
     }
-    translate.setDefaultLang(lang || 'en');
-    translate.use(lang || 'en');
+    translate.addLangs(this.languages);
+    translate.setDefaultLang(lang || 'ro');
+    translate.use(lang || 'ro');
   }
 }

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -74,6 +74,18 @@
       </li>
     </ul>
 
+    <div class="nav-item" ngbDropdown>
+      <span class="nav-link cursor-pointer" tabindex="1" ngbDropdownToggle id="selectedLanguage" role="button">
+        {{ "LANGUAGES" | translate }}
+      </span>
+      <div ngbDropdownMenu aria-labelledby="selectedLanguage" class="dropdown-menu dropdown-menu-right">
+        <a ngbDropdownItem *ngFor="let language of getAvailableLanguages()" (click)="setLanguage(language)"
+           class="cursor-pointer">
+          {{ language | uppercase }}
+        </a>
+      </div>
+    </div>
+
     <div *ngIf="isLoggedIn()" class="nav-item" ngbDropdown>
 
       <span class="nav-link cursor-pointer" tabindex="0" ngbDropdownToggle id="loggedInUser" role="button">

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,9 +1,10 @@
 import { Router } from '@angular/router';
-import { TokenService } from './../../core/token/token.service';
+import { TokenService } from '../../core/token/token.service';
 import { environment } from 'src/environments/environment';
 import { Component, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { logout } from 'src/app/store/user/user.actions';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-header',
@@ -12,9 +13,10 @@ import { logout } from 'src/app/store/user/user.actions';
 })
 export class HeaderComponent implements OnInit {
   isHamburgerClicked = false;
-  
+
   constructor(
-    private tokenService: TokenService, 
+    private tokenService: TokenService,
+    private translateService: TranslateService,
     private router: Router,
     private store: Store,
   ) {}
@@ -31,6 +33,20 @@ export class HeaderComponent implements OnInit {
 
   isLoggedIn() {
     return this.tokenService.isloggedIn();
+  }
+
+  getAvailableLanguages() {
+    return this.translateService.getLangs();
+  }
+
+  setLanguage(language: string) {
+    localStorage.setItem('language', language);
+    this.translateService.use(language);
+    this.translateService.setDefaultLang(language);
+    const prev = this.router.url;
+    this.router.navigate(['/']).then(_ => {
+      this.router.navigate([prev]);
+    });
   }
 
   logout() {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -192,5 +192,5 @@
   "NOTES_SENT_FAILURE": "Something went wrong",
 
   "LANGUAGE_NAME": "English",
-  "LANGUAGES": "Change language"
+  "LANGUAGES": "Languages"
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -192,5 +192,5 @@
   "NOTES_SENT_FAILURE": "Something went wrong",
 
   "LANGUAGE_NAME": "English",
-  "LANGUAGES": "Languages"
+  "LANGUAGES": "Change language"
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -189,5 +189,8 @@
 
   "NOTES_EMPTY_ROWS_MESSAGE": "There aren't any notes created",
   "NOTES_SENT_SUCCESS": "Notification sent",
-  "NOTES_SENT_FAILURE": "Something went wrong"
+  "NOTES_SENT_FAILURE": "Something went wrong",
+
+  "LANGUAGE_NAME": "English",
+  "LANGUAGES": "Languages"
 }

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -190,5 +190,8 @@
 
   "NOTES_EMPTY_ROWS_MESSAGE": "Nu există notițe create",
   "NOTES_SENT_SUCCESS": "Notificare trimisă",
-  "NOTES_SENT_FAILURE": "A apărut o eroare"
+  "NOTES_SENT_FAILURE": "A apărut o eroare",
+
+  "LANGUAGE_NAME": "Română",
+  "LANGUAGES": "Languages"
 }

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -193,5 +193,5 @@
   "NOTES_SENT_FAILURE": "A apărut o eroare",
 
   "LANGUAGE_NAME": "Română",
-  "LANGUAGES": "Languages"
+  "LANGUAGES": "Schimbă limba"
 }


### PR DESCRIPTION
### What does it fix?

Closes #305

Implements a language switch menu to the left of the logout menu.
Also switched the default language to RO.

<b>Screenshot:</b>
![image](https://user-images.githubusercontent.com/71708164/100669683-7060b980-3366-11eb-99b2-97067687e8af.png)

### How has it been tested?

Tested manually using local environment configs.