### PR TITLE
Fixed notes attachment not scaling properly.

### DIFF
--- a/src/app/answers/answer-details/answer-details.component.scss
+++ b/src/app/answers/answer-details/answer-details.component.scss
@@ -111,5 +111,10 @@
     overflow: hidden;
     max-height: 45rem;
     margin-top: 2rem;
+
+    img {
+      max-height: 100%;
+      max-width: 100%;
+    }
   }
 }


### PR DESCRIPTION
### What does it fix?

Closes #306 

This PR fixes notes attachments not scaling properly.

<b>Screenshots:</b>
| Before: ![image](https://user-images.githubusercontent.com/71708164/100674911-9be7a200-336e-11eb-9119-81ed5c30b59a.png) | After: ![image](https://user-images.githubusercontent.com/71708164/100674940-ac981800-336e-11eb-9ee0-ad0545b0b79a.png) |
|-------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|

### How has it been tested?

Tested manually using local environment configs.