### PR TITLE
Feature/308 fix forms repeated delete issue

### DIFF
--- a/src/app/components/forms/forms.component.ts
+++ b/src/app/components/forms/forms.component.ts
@@ -68,9 +68,10 @@ export class FormsComponent implements OnInit, OnDestroy {
     const modalRef = this._modalService.open(ConfirmationModalComponent)
     modalRef.componentInstance.message = 'Are you sure you want to delete this record?';
     modalRef.result
-      .then(() => this.store.dispatch(new FormDeleteAction(Form.fromMetaData(formDetails))))
-      .catch(() => {
-      });
+      .then(() => {
+        this.store.dispatch(new FormDeleteAction(Form.fromMetaData(formDetails)));
+      })
+      .catch(console.error);
   }
 
   public setFormDraftStatus(formDetails: FormDetails, value: boolean) {

--- a/src/app/store/form/form.effects.ts
+++ b/src/app/store/form/form.effects.ts
@@ -61,10 +61,9 @@ export class FormEffects {
               loadedForm.id = formId;
               loadedForm.formSections = sections;
               return new FullyLoadFormCompleteAction(loadedForm);
-            })
-          )
-      ),
-      catchError(() => observableOf(new FormErrorAction()))
+            }),
+            catchError(() => observableOf(new FormErrorAction()))
+          ))
     );
 
   @Effect()
@@ -73,9 +72,9 @@ export class FormEffects {
       ofType(FormActionTypes.UPLOAD),
       switchMap((a: FormUploadAction) =>
         this.formsService.saveForm(a.form).pipe(
-          map(_ => new FormUploadCompleteAction())
-        )),
-      catchError(() => observableOf(new FormErrorAction()))
+          map(_ => new FormUploadCompleteAction()),
+          catchError(() => observableOf(new FormErrorAction()))
+        ))
     );
 
   @Effect()
@@ -84,9 +83,9 @@ export class FormEffects {
       ofType(FormActionTypes.UPLOAD_PUBLISH),
       switchMap((a: FormUploadAction) =>
         this.formsService.saveAndPublishForm(a.form).pipe(
-          map(_ => new FormUploadCompleteAction())
-        )),
-      catchError(() => observableOf(new FormErrorAction()))
+          map(_ => new FormUploadCompleteAction()),
+          catchError(() => observableOf(new FormErrorAction()))
+        ))
     );
 
   @Effect()
@@ -102,20 +101,23 @@ export class FormEffects {
       ofType(FormActionTypes.UPDATE),
       switchMap((a: FormUpdateAction) =>
         this.formsService.updateForm(a.form).pipe(
-          map(_ => new FormLoadAction(a.form.draft, true))
-        )),
-      catchError(() => observableOf(new FormErrorAction()))
+          map(_ => new FormLoadAction(a.form.draft, true)),
+          catchError(() => observableOf(new FormErrorAction()))
+        ))
     );
 
   @Effect()
   formDelete = this.actions
     .pipe(
+      tap(a => {
+        console.log('action', a);
+      }),
       ofType(FormActionTypes.DELETE),
       switchMap((a: FormDeleteAction) =>
         this.formsService.deleteForm(a.form.id).pipe(
           map(_ => new FormLoadAction(a.form.draft, true)),
-        )),
-      catchError(() => observableOf(new FormErrorAction()))
+          catchError(() => observableOf(new FormErrorAction()))
+        ))
     );
 
   fetchAllFormTabs = createEffect(

--- a/src/app/store/form/form.effects.ts
+++ b/src/app/store/form/form.effects.ts
@@ -1,4 +1,5 @@
-import {of as observableOf} from 'rxjs';
+import { of as observableOf } from 'rxjs';
+
 import {catchError, filter, map, mergeAll, mergeMap, switchMap, tap, withLatestFrom} from 'rxjs/operators';
 import {
   fetchAllFormTabs,
@@ -14,13 +15,13 @@ import {
   FullyLoadFormCompleteAction
 } from './form.actions';
 import {Actions, createEffect, Effect, ofType} from '@ngrx/effects';
-import {Injectable} from '@angular/core';
-import {FormSection} from '../../models/form.section.model';
-import {FormsService} from '../../services/forms.service';
-import {Router} from '@angular/router';
-import {Form} from '../../models/form.model';
-import {Store} from '@ngrx/store';
-import {form, getFormItems, getFullyLoadedForms} from './form.selectors';
+import { Injectable } from '@angular/core';
+import { FormSection } from '../../models/form.section.model';
+import { FormsService } from '../../services/forms.service';
+import { Router } from '@angular/router';
+import { Form } from '../../models/form.model';
+import { Store } from '@ngrx/store';
+import { form, getFormItems, getFullyLoadedForms } from './form.selectors';
 
 @Injectable()
 export class FormEffects {
@@ -30,8 +31,7 @@ export class FormEffects {
     private actions: Actions,
     private router: Router,
     private store: Store
-  ) {
-  }
+  ) { }
 
   @Effect()
   loadFormAction = this.actions
@@ -109,9 +109,6 @@ export class FormEffects {
   @Effect()
   formDelete = this.actions
     .pipe(
-      tap(a => {
-        console.log('action', a);
-      }),
       ofType(FormActionTypes.DELETE),
       switchMap((a: FormDeleteAction) =>
         this.formsService.deleteForm(a.form.id).pipe(

--- a/src/app/store/form/form.effects.ts
+++ b/src/app/store/form/form.effects.ts
@@ -1,6 +1,5 @@
-import { of as observableOf } from 'rxjs';
-
-import {catchError, filter, map, mergeAll, mergeMap, switchMap, take, tap, withLatestFrom} from 'rxjs/operators';
+import {of as observableOf} from 'rxjs';
+import {catchError, filter, map, mergeAll, mergeMap, switchMap, tap, withLatestFrom} from 'rxjs/operators';
 import {
   fetchAllFormTabs,
   FormActionTypes,
@@ -15,13 +14,13 @@ import {
   FullyLoadFormCompleteAction
 } from './form.actions';
 import {Actions, createEffect, Effect, ofType} from '@ngrx/effects';
-import { Injectable } from '@angular/core';
-import { FormSection } from '../../models/form.section.model';
-import { FormsService } from '../../services/forms.service';
-import { Router } from '@angular/router';
-import { Form } from '../../models/form.model';
-import { Store } from '@ngrx/store';
-import { form, getFormItems, getFullyLoadedForms } from './form.selectors';
+import {Injectable} from '@angular/core';
+import {FormSection} from '../../models/form.section.model';
+import {FormsService} from '../../services/forms.service';
+import {Router} from '@angular/router';
+import {Form} from '../../models/form.model';
+import {Store} from '@ngrx/store';
+import {form, getFormItems, getFullyLoadedForms} from './form.selectors';
 
 @Injectable()
 export class FormEffects {
@@ -31,7 +30,8 @@ export class FormEffects {
     private actions: Actions,
     private router: Router,
     private store: Store
-  ) { }
+  ) {
+  }
 
   @Effect()
   loadFormAction = this.actions
@@ -53,14 +53,14 @@ export class FormEffects {
     .pipe(
       ofType(FormActionTypes.LOAD_ONE_FORM_FULLY),
       map((a: FullyLoadFormAction) => a.formId),
-        mergeMap(formId =>
+      mergeMap(formId =>
         this.formsService.getForm(formId)
           .pipe(
             map((sections: FormSection[]) => {
-              const form = new Form();
-              form.id = formId;
-              form.formSections = sections;
-              return new FullyLoadFormCompleteAction(form);
+              const loadedForm = new Form();
+              loadedForm.id = formId;
+              loadedForm.formSections = sections;
+              return new FullyLoadFormCompleteAction(loadedForm);
             })
           )
       ),
@@ -93,7 +93,6 @@ export class FormEffects {
   formUploadSuccess = this.actions
     .pipe(
       ofType(FormActionTypes.UPLOAD_COMPLETE),
-      take(1),
       tap(_ => this.router.navigate(['formulare']))
     );
 
@@ -103,7 +102,7 @@ export class FormEffects {
       ofType(FormActionTypes.UPDATE),
       switchMap((a: FormUpdateAction) =>
         this.formsService.updateForm(a.form).pipe(
-          map(_ => new FormLoadAction(a.form.draft,true))
+          map(_ => new FormLoadAction(a.form.draft, true))
         )),
       catchError(() => observableOf(new FormErrorAction()))
     );
@@ -112,7 +111,6 @@ export class FormEffects {
   formDelete = this.actions
     .pipe(
       ofType(FormActionTypes.DELETE),
-      take(1),
       switchMap((a: FormDeleteAction) =>
         this.formsService.deleteForm(a.form.id).pipe(
           map(_ => new FormLoadAction(a.form.draft, true)),
@@ -125,7 +123,7 @@ export class FormEffects {
       ofType(fetchAllFormTabs),
       withLatestFrom(this.store.select(getFormItems), this.store.select(getFullyLoadedForms)),
       filter(([, formTabs, loadedForms]) => formTabs.length !== Object.keys(loadedForms).length),
-      map(([, formTabs, loadedForms]) =>  formTabs.filter(f => !loadedForms[f.id]).map(f => new FullyLoadFormAction(f.id))),
+      map(([, formTabs, loadedForms]) => formTabs.filter(f => !loadedForms[f.id]).map(f => new FullyLoadFormAction(f.id))),
       mergeAll(),
     )
   )


### PR DESCRIPTION
### What does it fix?
Fixed form delete issue. Also includes fixes for most forms effects in error cases.
Was caused by `take(1)` in Effect observers and [this issue](https://medium.com/city-pantry/handling-errors-in-ngrx-effects-a95d918490d9).

Closes #308 

### How has it been tested?
Tested locally with `test` user, ensuring API calls were made repeatedly for different actions (add published/draft form, delete, edit, list all).