### PR TITLE
Use observer and station ID for selecting threads

### DIFF
--- a/src/app/answers/answer-details/answer-details.component.ts
+++ b/src/app/answers/answer-details/answer-details.component.ts
@@ -12,7 +12,7 @@ import { BASE_BUTTON_VARIANTS, Variants } from 'src/app/shared/base-button/base-
 import { fetchAllFormTabs, FullyLoadFormAction } from 'src/app/store/form/form.actions';
 import { AppState } from 'src/app/store/store.module';
 import { DisplayedNote, SectionsState }  from '../answers.model';
-import { getSelectedAnswersAsObject, getSelectedAnswersLoadingStatus, getSpecificThreadByObserver } from '../../store/answer/answer.selectors';
+import { getSelectedAnswersAsObject, getSelectedAnswersLoadingStatus, getSpecificThreadByIds } from '../../store/answer/answer.selectors';
 import { getFormItems, getFullyLoadedForms } from '../../store/form/form.selectors';
 
 import { getNotes, getNotesAsObject, getNotesLoadingStatus, getNotesMergedWithQuestions } from '../../store/note/note.selectors';
@@ -47,7 +47,10 @@ export class AnswerDetailsComponent implements OnInit {
     { name: this.translate.get('ANSWERS_DATE_AND_TIME'), propertyName: 'observerArrivalTime', },
   ];
 
-  crtPollingStation$ = this.store.select(getSpecificThreadByObserver, +this.route.snapshot.params.idObserver)
+  crtPollingStation$ = this.store.select(getSpecificThreadByIds, {
+    idObserver: +this.route.snapshot.params.idObserver,
+    idPollingStation: +this.route.snapshot.params.idPollingStation,
+  })
   .pipe(
     tap(v => v === void 0 && this.router.navigate(['../../'], { relativeTo: this.route })),
     filter(Boolean),

--- a/src/app/answers/answer-notification/answer-notification.component.ts
+++ b/src/app/answers/answer-notification/answer-notification.component.ts
@@ -5,7 +5,7 @@ import { concat, Observable, of, timer } from 'rxjs';
 import { catchError, map, mapTo, pluck, tap } from 'rxjs/operators';
 import { NotificationsService } from 'src/app/services/notifications.service';
 import { BASE_BUTTON_VARIANTS, Variants } from 'src/app/shared/base-button/base-button.component';
-import { getSpecificThreadByObserver } from 'src/app/store/answer/answer.selectors';
+import { getSpecificThreadByIds } from 'src/app/store/answer/answer.selectors';
 import { AppState } from 'src/app/store/store.module';
 
 @Component({
@@ -14,7 +14,10 @@ import { AppState } from 'src/app/store/store.module';
   styleUrls: ['./answer-notification.component.scss']
 })
 export class AnswerNotificationComponent {
-  observerName$ = this.store.select(getSpecificThreadByObserver, +this.route.snapshot.params.idObserver)
+  observerName$ = this.store.select(getSpecificThreadByIds, {
+    idObserver: +this.route.snapshot.params.idObserver,
+    idPollingStation: +this.route.snapshot.params.idPollingStation,
+  })
     .pipe(
       tap(v => v === void 0 && this.router.navigate(['/answers'], { relativeTo: this.route })),
       pluck('observerName'),

--- a/src/app/store/answer/answer.selectors.ts
+++ b/src/app/store/answer/answer.selectors.ts
@@ -37,9 +37,18 @@ export const getAnswerThreads = createSelector(
   (state: AnswerState) => state.threads ? state.threads : [],
 );
 
-export const getSpecificThreadByObserver = createSelector(
+/** IDs uniquely identifying an answer thread. */
+type AnswerThreadIds = {
+  idObserver: number;
+  idPollingStation: number;
+};
+
+export const getSpecificThreadByIds = createSelector(
   getAnswerThreads,
-  (threads: AnswerThread[], observerId: number) => threads.find(thread => thread.idObserver === observerId)
+  (threads: AnswerThread[], props: AnswerThreadIds) =>
+    threads.find(thread => (thread.idObserver === props.idObserver) &&
+      (thread.idPollingStation == props.idPollingStation)
+    )
 );
 
 export const getSelectedAnswersLoadingStatus = createSelector(


### PR DESCRIPTION
### What does it fix?

Fixes #310. 

Modifies the answer thread components to use both the observer ID and the polling station ID when displaying the details of an answer threads.

Before, it only used the observer ID, assuming an observer could not have answer threads for multiple polling stations.

### How has it been tested?

Using the QA environment. Only tested the effects on the `AnswerDetailsComponent`, but the changes should also work to ensure the correct data in `AnswerNotificationComponent`.