### PR TITLE
show toaster on success and on error, clear form on success

### DIFF
--- a/src/app/components/notifications/notifications.component.ts
+++ b/src/app/components/notifications/notifications.component.ts
@@ -1,7 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {CountyPollingStationInfo, NotificationsService,} from '../../services/notifications.service';
 import {IDropdownSettings} from 'ng-multiselect-dropdown';
-import {TranslateService} from '@ngx-translate/core';
 import {FormControl, FormGroup, Validators} from '@angular/forms';
 import {ObserversService} from '../../services/observers.service';
 import {SentGlobalNotificationModel} from '../../models/notification.model';
@@ -9,6 +8,8 @@ import {ActivatedRoute, Params} from '@angular/router';
 import {Observable} from 'rxjs';
 import {filter, first, map, tap} from 'rxjs/operators';
 import {Location} from '@angular/common';
+import { ToastrService } from 'ngx-toastr';
+import { TranslateService } from '@ngx-translate/core';
 
 export interface NotificationsRouteParams extends Params {
   toObserverIds: string;
@@ -44,6 +45,7 @@ export class NotificationsComponent implements OnInit {
   constructor(
     private notificationsService: NotificationsService,
     private observersService: ObserversService,
+    private toastrService: ToastrService,
     private translate: TranslateService,
     private route: ActivatedRoute,
     private location: Location
@@ -112,13 +114,29 @@ export class NotificationsComponent implements OnInit {
       if (this.usingObserverFilters) {
         this.notificationsService
           .pushNotification({...notification, recipients: this.filteredObserverIds})
-          .subscribe(console.log);
+          .subscribe({
+            next: result => this.onNotificationSubmitted(),
+            error: errorMsg => this.onNotificationError()
+          });
       } else {
         this.notificationsService
           .pushNotificationGlobally(notification)
-          .subscribe(console.log);
+          .subscribe({
+            next: result => this.onNotificationSubmitted(),
+            error: errorMsg => this.onNotificationError()
+          });
       }
     }
+  }
+
+  private onNotificationSubmitted() {
+    this.notificationFormSubmitted = false;
+    this.toastrService.success(this.translate.instant('NOTIFICATION_SENT_SUCCESS'), this.translate.instant('SUCCESS'));
+    this.notificationForm.reset();
+  }
+
+  private onNotificationError() {
+    this.toastrService.error(this.translate.instant('NOTIFICATION_SENT_ERROR'), this.translate.instant('ERROR'));
   }
 
   private createGlobalNotification(): SentGlobalNotificationModel {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -101,6 +101,8 @@
   "SEND_NOTIFICATIONS_TO_ALL": "Send notification to all observers",
   "SEND_NOTIFICATIONS_TO_N_OBSERVERS": "Send notification to %d observers",
   "NOTIFICATION_SEND_CONFIRMATION": "You are about to send this message to %d observers. Are you sure?",
+  "NOTIFICATION_SENT_SUCCESS": "The message has been successfully sent",
+  "NOTIFICATION_SENT_ERROR": "Something went wrong while sending the message. Try again.",
 
   "NOTIFICATION_HISTORY": "Notification history",
   "SENT_BY": "Sent by",
@@ -160,6 +162,7 @@
   "SELECT_FILE": "Select file",
   "IMPORT": "Import",
   "SUCCESS": "Success",
+  "ERROR": "Error",
   "FROM": "From",
   "TO": "To",
   "NGO": "NGO",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -102,6 +102,8 @@
   "SEND_NOTIFICATIONS_TO_ALL": "Trimite notificare către toți observatorii",
   "SEND_NOTIFICATIONS_TO_N_OBSERVERS": "Trimite notificare către %d observatori",
   "NOTIFICATION_SEND_CONFIRMATION": "Ești sigur că vrei să trimiți notificarea către %d observator(i)?",
+  "NOTIFICATION_SENT_SUCCESS": "Mesajul a fost trimis cu succes",
+  "NOTIFICATION_SENT_ERROR": "A apărut o eroare la trimiterea mesajului. Încearcă din nou.",
 
   "NOTIFICATION_HISTORY": "Istoric notificări",
   "SENT_BY": "Trimis de",
@@ -161,6 +163,7 @@
   "SELECT_FILE": "Selectaţi fișierul",
   "IMPORT": "Importaţi",
   "SUCCESS": "Succes",
+  "ERROR": "Eroare",
   "FROM": "De la",
   "TO": "Pana la",
   "NGO": "ONG",


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes #334  

<!-- Please mention the main changes this PR brings. -->
Shows a toaster with a success message when a notification has been successfully sent, and clears the notification form. Shows a toaster with an error message when an error occurs when sending a notification.

### How has it been tested?

<!-- Please describe the tests that you ran to verify your changes. -->
I tested by mocking a successful response from the notification service, and verifying that the success message was shown and the form was cleared (without displaying validation errors).
Also I checked that if the notification service returned an error, the error toaster was shown. 

<!-- If applicable, mention any known issues with the pull request -->
The error toaster has some visual issue: there seems to be a large white arc overlaying the red background. This seems to be because the background image (in toastr.scss) was displayed in a weird way. I checked if this was also a problem in other parts of the application where the error toaster was shown and this seemed to be the case.
I didn't fix this, since while I had an idea of what it could look like (I'm guessing the image should be displayed small in the upper right corner), I wasn't sure if that was correct.

Also, when I ran lint, there were a lot of lint errors in files that I didn't touch. I didn't correct this :).

Lastly, I acquired the Romanian texts through Google translate, since I can't speak Romanian 😅 
