### PR TITLE
329 Add answer refresh mechanism

### DIFF
--- a/src/app/answers/answers/answers.component.html
+++ b/src/app/answers/answers/answers.component.html
@@ -4,6 +4,12 @@
       <h3 class="mb-0 c-answers__header-title">{{ 'ANSWERS_HEADER_TITLE' | translate }}</h3>
       <i class="h-vertical-line"></i>
       <span class="font-weight-bold h-is-muted">{{ (answerState$ | async).totalItems }} total</span>
+      <button type="button" class="btn btn-link ml-2" (click)="refreshAnswers()">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16">
+          <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/>
+          <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/>
+        </svg>
+      </button>
     </div>
 
     <div class="d-flex">

--- a/src/app/answers/answers/answers.component.ts
+++ b/src/app/answers/answers/answers.component.ts
@@ -113,6 +113,10 @@ export class AnswersComponent implements OnInit {
     this.store.dispatch(new FormLoadAction());
   }
 
+  refreshAnswers() {
+    this.store.dispatch(new LoadAnswerPreviewAction(1, undefined, true));
+  }
+
   private isValidValue(value) {
     return value !== null && value !== '';
   }

--- a/src/app/services/answers.service.ts
+++ b/src/app/services/answers.service.ts
@@ -5,13 +5,15 @@ import { ApiService, QueryParamBuilder } from '../core/apiService/api.service';
 import { AnswerExtraConstructorData } from '../models/answer.extra.model';
 import {HttpParams} from '@angular/common/http';
 import {first} from 'rxjs/operators';
+import {AnswerThread} from '../models/answer.thread.model';
+import {AnswerFilters} from '../models/answer.filters.model';
 
 @Injectable({
 	providedIn: 'root'
 })
 export class AnswersService {
 	private baseUrl: string = environment.apiUrl;
-	private extraDetailsURL = this.baseUrl + '/api/v1/answers/pollingStationInfo';
+  private extraDetailsURL = Location.joinWithSlash(this.baseUrl, '/api/v1/answers/pollingStationInfo');
 
 	constructor(private http: ApiService) { }
 
@@ -46,6 +48,45 @@ export class AnswersService {
 			},
 		});
 	}
+
+
+  getAnswers(payload) {
+    const answersUrl: string = Location.joinWithSlash(this.baseUrl, '/api/v1/answers');
+
+    return this.http.get<{
+      data: AnswerThread[];
+      totalItems: number;
+      totalPages: number;
+      page: number,
+      pageSize: number,
+    }>(answersUrl, {
+      params: this.buildLoadAnswerPreviewFilterParams(payload),
+    });
+  }
+
+  private buildLoadAnswerPreviewFilterParams(payload: {
+    page: number;
+    pageSize: number;
+    refresh: boolean;
+    answerFilters?: AnswerFilters;
+  }): HttpParams {
+    // adding these upfront since they will always be present
+    let params = new HttpParams()
+      .append('page', payload.page + '')
+      .append('pageSize', payload.pageSize + '');
+
+    if (payload && payload.answerFilters) {
+      for (const k in payload.answerFilters) {
+        if (payload.answerFilters.hasOwnProperty(k)) {
+          const val = payload.answerFilters[k];
+
+          params = (!!val || val === 0) ? params.append(k, val + '') : params;
+        }
+      }
+    }
+
+    return params;
+  }
 }
 
 export interface AnswersPackFilter {

--- a/src/app/store/answer/answer.actions.ts
+++ b/src/app/store/answer/answer.actions.ts
@@ -126,3 +126,17 @@ export const setAnswersLoadingStatus = createAction(
     '[Answers Page] Set Answer\'s Loading Status',
     props<{ isLoading: boolean }>()
 );
+
+export interface TimerPayload {timer: number}
+
+export const setThreadsRecentlyRefreshedTimer = createAction(
+  '[Answers Page] Store timer when Answer Threads were recently refreshed',
+  props<TimerPayload>()
+);
+
+export interface RecentlyRefreshedPayload {recentlyRefreshed: boolean}
+
+export const setThreadsRecentlyRefreshed = createAction(
+  '[Answers Page] Answer Threads were recently refreshed',
+  props<RecentlyRefreshedPayload>()
+);

--- a/src/app/store/answer/answer.reducer.ts
+++ b/src/app/store/answer/answer.reducer.ts
@@ -3,11 +3,21 @@ import { Note } from '../../models/note.model';
 import { shouldLoadPage } from '../../shared/pagination.service';
 import { AnswerThread } from '../../models/answer.thread.model';
 import { CompletedQuestion } from '../../models/completed.question.model';
-import { AnswerActions, AnswerActionTypes, setAnswersLoadingStatus, updateFilters, updatePageInfo } from './answer.actions';
+import {
+  AnswerActions,
+  AnswerActionTypes,
+  setAnswersLoadingStatus,
+  setThreadsRecentlyRefreshedTimer,
+  TimerPayload,
+  updateFilters,
+  updatePageInfo
+} from './answer.actions';
 import { AnswerFilters } from '../../models/answer.filters.model';
 import { ActionCreator } from '@ngrx/store';
 export class AnswerState {
     threads: AnswerThread[];
+    threadsRecentlyRefreshed = false;
+    threadsRecentlyRefreshedTimer: number = null;
     urgent: boolean = undefined;
     page = 1;
     pageSize = 10;
@@ -35,9 +45,9 @@ export class AnswerState {
 }
 export let initialAnswerState: AnswerState = new AnswerState();
 
-export function answerReducer(state = initialAnswerState, action: AnswerActions | any) {
+export function answerReducer(state = initialAnswerState, action: AnswerActions | any): AnswerState {
     switch (action.type) {
-        
+
         case setAnswersLoadingStatus.type:
             return {
                 ...state,
@@ -46,7 +56,7 @@ export function answerReducer(state = initialAnswerState, action: AnswerActions 
 
         case updateFilters.type: {
             const { type, ...payload } = action;
-            
+
             return {
                 ...state,
                 answerFilters: payload,
@@ -110,6 +120,13 @@ export function answerReducer(state = initialAnswerState, action: AnswerActions 
                 answerExtraLoading: false,
                 selectedError: true
             });
+        case setThreadsRecentlyRefreshedTimer.type:
+            const {timer} = action as TimerPayload;
+            return {
+              ...state,
+              threadsRecentlyRefreshed: timer !== null,
+              threadsRecentlyRefreshedTimer: timer
+            };
         default:
             return state;
     }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,4 +10,5 @@ export const environment: EnvironmentConfig = {
   observerGuideUrl:
     'https://fiecarevot.ro/wp-content/uploads/2020/12/Manual-observatori-FV-parlamentare2020.pdf',
   apiUrl: 'https://api.votemonitor.org/',
+  answersRefreshTimeMs: 60000
 };

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -5,4 +5,5 @@ export interface EnvironmentConfig {
     production: boolean;
     observerGuideUrl: string;
     apiUrl: string;
+    answersRefreshTimeMs?: number;
 }


### PR DESCRIPTION
### What does it fix?
Closes #329 

Added a timer that allows answer refreshing, which resets itself after 1 min.
Added refresh button in Answers page.
Refactoring: extracted `getAnswers` method from effect to service.

### How has it been tested?
Locally, with user "test" and public API.
Happy path:
1. Open network tab in console
2. Go to Answers page -> notice "/answers" request
3. Go to another page, wait at least 1 minute, come back to Answers -> notice the "/answers" request
4. Go to another page, wait less than 1 minute, come back to Answers -> no new requests
5. Click on Refresh icon -> notice the new "/answers" request