### PR TITLE
[Bug] [#333] Adding error message on observer delete error

### DIFF
--- a/src/app/components/observers/observers.component.ts
+++ b/src/app/components/observers/observers.component.ts
@@ -257,6 +257,8 @@ export class ObserversComponent implements OnInit, OnDestroy {
         .subscribe(() => {
           this.toastrService.warning(this.translateService.instant('SUCCESS'), this.translateService.instant('OBSERVER_DELETE_SUCCESS'));
           this.loadObservers(1);
+        }, () => {
+          this.toastrService.error(this.translateService.instant('ERROR'), this.translateService.instant('OBSERVER_DELETE_ERROR'));
         });
     }
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -136,6 +136,7 @@
   "OBSERVER_EDIT": "Edit Observer",
   "OBSERVER_DELETE_CONFIRMATION": "Are you sure you want to remove this observer?",
   "OBSERVER_DELETE_SUCCESS": "Observer has been removed",
+  "OBSERVER_DELETE_ERROR": "There was an error deleting the observer",
   "OBSERVER_POLLING_STATIONS": "Visited Polling Stations",
   "OBSERVERS_SELECTED": "Observers Selected",
   "OBSERVERS_IMPORT": "Import Observers",

--- a/src/assets/i18n/ro.json
+++ b/src/assets/i18n/ro.json
@@ -137,6 +137,7 @@
   "OBSERVER_EDIT": "Editaţi Observator",
   "OBSERVER_DELETE_CONFIRMATION": "Sunteti sigur ca doriti sa stergeti acest observator?",
   "OBSERVER_DELETE_SUCCESS": "Observatorul a fost sters",
+  "OBSERVER_DELETE_ERROR": "A apărut o eroare la ștergerea observatorului",
   "OBSERVER_POLLING_STATIONS": "Secţii De Votare Vizitate",
   "OBSERVERS_SELECTED": "Observatori Selectaţi",
   "OBSERVERS_IMPORT": "Importaţi Observatori",


### PR DESCRIPTION
<!--
### Requirements for making a pull request

Thank you for contributing to our project!

Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
-->

### What does it fix?
<!--
If it is related to an open issue, please link the issue here. 
-->

Closes #333  

<!-- Please mention the main changes this PR brings. -->

### How has it been tested?
Tested locally, screenshot to verify

New Error Message (in EN) on Observer Delete Error
![observer-delete-error-message](https://user-images.githubusercontent.com/21061492/138564451-0419f494-ae63-4f0e-b83a-bf3751dc6069.PNG)

New Error Message (in RO) on Observer Delete Error (hopefully Google Translate is right 😊)
![observer-delete-error-message-ro](https://user-images.githubusercontent.com/21061492/138564485-ecf04f25-5984-4835-b741-df265e7a9c67.PNG)

Existing Observer Delete Success Message (still there and working..)
![observer-delete-success-message](https://user-images.githubusercontent.com/21061492/138564493-a62d0987-6da9-45bc-8580-84b8ea202219.PNG)



<!-- Please describe the tests that you ran to verify your changes. -->


<!-- If applicable, mention any known issues with the pull request -->
