### PR TITLE
validation added for form and disabled the saves

### DIFF
--- a/src/app/components/forms/form-create/form-create.component.html
+++ b/src/app/components/forms/form-create/form-create.component.html
@@ -1,15 +1,17 @@
 <div class="container-fluid">
   <div class="d-flex flex-column mb-4">
     <div class="cursor-pointer ">
-        <span (click)="onBackPressed()">&#8592; {{ "BACK" | translate }}</span>
+      <span (click)="onBackPressed()">&#8592; {{ "BACK" | translate }}</span>
     </div>
     <div class="control-container d-flex justify-content-between mt-2">
       <h4>{{ "FORM_EDIT" | translate }}</h4>
       <div class="btn-group-separated" role="group" aria-label="save group">
-        <button class="btn-outline-secondary btn" (click)="saveForm()" type="submit">
+        <button class="btn-outline-secondary btn" (click)="saveForm()" type="submit"
+          [disabled]="!formDetailsFormGroup.valid">
           {{ "FORM_SAVE_DRAFT" | translate }}
         </button>
-        <button class="btn-warning btn ml-2" (click)="saveAndPublishForm()" type="submit">
+        <button class="btn-warning btn ml-2" (click)="saveAndPublishForm()" type="submit"
+          [disabled]="!formDetailsFormGroup.valid">
           {{ "FORM_PUBLISH" | translate }}
         </button>
       </div>
@@ -23,63 +25,48 @@
           <div class="col-lg-6">
             <div class="form-group">
               <label for="form-title">{{ "FORM_TITLE" | translate }}</label>
-              <input
-                class="form-control"
-                id="form-title"
-                formControlName="description"
-                placeholder="{{ 'FORM_TITLE_PLACEHOLDER' | translate }}"
-              />
+              <input class="form-control" id="form-title" formControlName="title"
+                placeholder="{{ 'FORM_TITLE_PLACEHOLDER' | translate }}" />
+              <div class="invalid-feedback"
+                *ngIf="!formDetailsFormGroup.controls['title'].valid && formDetailsFormGroup.controls['title'].touched">
+                Title is required!
+              </div>
             </div>
             <div class="form-group">
               <label for="form-cde">{{ "FORM_CODE" | translate }}</label>
-              <input
-                class="form-control"
-                formControlName="code"
-                id="form-code"
-                placeholder="{{ 'FORM_CODE_PLACEHOLDER' | translate }}"
-              />
+              <input class="form-control" formControlName="code" id="form-code"
+                placeholder="{{ 'FORM_CODE_PLACEHOLDER' | translate }}" />
+              <div class="invalid-feedback"
+                *ngIf="!formDetailsFormGroup.controls['code'].valid && formDetailsFormGroup.controls['code'].touched">
+                Code is required!
+              </div>
             </div>
           </div>
           <div class="col-lg-6">
             <div class="form-group">
               <label for="form-cde">{{ "FORM_DESCRIPTION" | translate }}</label>
-              <textarea
-                class="form-control"
-                formControlName="description"
-                id="form-description"
+              <textarea class="form-control" formControlName="description" id="form-description"
                 placeholder="{{ 'FORM_DESCRIPTION_PLACEHOLDER' | translate }}"></textarea>
+            </div>
+            <div class="invalid-feedback"
+              *ngIf="!formDetailsFormGroup.controls['description'].valid && formDetailsFormGroup.controls['description'].touched">
+              Description is required!
             </div>
           </div>
         </div>
         <div class="form-group form-check">
-          <input
-            type="checkbox"
-            class="form-check-input"
-            id="form-diaspora"
-            formControlName="diaspora"
-          />
+          <input type="checkbox" class="form-check-input" id="form-diaspora" formControlName="diaspora" />
           <label for="form-diaspora" class="form-check-label">{{
             "FORM_ONLY_DIASPORA" | translate
-          }}</label>
+            }}</label>
         </div>
       </form>
     </div>
   </div>
 
-  <div
-    class="section-list"
-    cdkDropList
-    (cdkDropListDropped)="onReorder($event)"
-  >
-    <div
-      *ngFor="let section of sectionFormGroupsArray; let i = index"
-      cdkDrag
-      class="section"
-    >
-      <app-section
-        [sectionFormGroup]="section"
-        (sectionDeleteEventEmitter)="onSectionDelete(i)"
-      >
+  <div class="section-list" cdkDropList (cdkDropListDropped)="onReorder($event)">
+    <div *ngFor="let section of sectionFormGroupsArray; let i = index" cdkDrag class="section">
+      <app-section [sectionFormGroup]="section" (sectionDeleteEventEmitter)="onSectionDelete(i)">
       </app-section>
     </div>
   </div>

--- a/src/app/components/forms/form-create/form-create.component.scss
+++ b/src/app/components/forms/form-create/form-create.component.scss
@@ -57,5 +57,9 @@ textarea {
   min-height: 124px; // aligns to 2 inputs in a column layout
 }
 
+//bootstrap override
+.invalid-feedback {
+  display: block;
+}
 
 

--- a/src/app/components/forms/form-groups-builder.ts
+++ b/src/app/components/forms/form-groups-builder.ts
@@ -1,10 +1,11 @@
-import {FormBuilder, Validators} from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 
 
 export function initFormFormGroup(formBuilder: FormBuilder) {
   return formBuilder.group({
-    description: formBuilder.control(''),
-    code: formBuilder.control(''),
+    title: formBuilder.control(null, Validators.required),
+    description: formBuilder.control(null, Validators.required),
+    code: formBuilder.control(null, Validators.required),
     diaspora: formBuilder.control(false),
     formSections: formBuilder.array([], Validators.required)
   });


### PR DESCRIPTION

### What does it fix?
The forms page didn't have any validation on the front-end for empty/null inputs.
Also description was on 2 inputs fields, updated to use "title" with the help @idormenco working on the api.

Closes #360

@aniri, this should help with empty calls.

### How has it been tested?

Validation appears after the control has been touched.
Save/Publish buttons are disabled until the form is valid also.

Invalid form:
![image](https://user-images.githubusercontent.com/44526601/138874998-a1b68fda-efdb-4605-9fb5-0aadfc995082.png)

After adding the required fields and a section you can not submit
![image](https://user-images.githubusercontent.com/44526601/138875608-67dead37-52d2-4684-9a35-c4b61aeaae9c.png)

